### PR TITLE
Make pickdate go install-able

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -34,7 +34,7 @@ func ValidateFlags() (Config, error) {
 		pflag.CommandLine.PrintDefaults()
 		os.Exit(1)
 	}
-	
+
 	startAt, err := time.Parse("2006/01/02", startAtF)
 	if err != nil {
 		return Config{}, err

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module pickdate
+module github.com/maraloon/pickdate
 
 go 1.23.3
 

--- a/main.go
+++ b/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"time"
 
-	"pickdate/config"
-	"pickdate/keymap"
+	"github.com/maraloon/pickdate/config"
+	"github.com/maraloon/pickdate/keymap"
 
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"


### PR DESCRIPTION
I tried to `go install` pickdate:

```shell
$ go install github.com/maraloon/pickdate@latest

go: github.com/maraloon/pickdate@latest: version constraints conflict:
	github.com/maraloon/pickdate@v0.0.1: parsing go.mod:
	module declares its path as: pickdate
	       but was required as: github.com/maraloon/pickdate
```

This PR changes the `module` in go.mod (and updates imports to match) so that the program is go install-able. Also ran `go fmt`.